### PR TITLE
Update provisioned gradle

### DIFF
--- a/provisioning/pre-package-bootstrap.sh
+++ b/provisioning/pre-package-bootstrap.sh
@@ -29,7 +29,7 @@ apt-get update
 
 echo "Installing dependencies"
 apt-get install -y build-essential git-core zlib1g-dev libssl-dev \
-  libreadline-dev libyaml-dev subversion maven gradle-3.1 nodejs rdiff-backup \
+  libreadline-dev libyaml-dev subversion maven gradle-3.5.1 nodejs rdiff-backup \
   zip libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev \
   libcurl4-openssl-dev libffi-dev openjdk-8-jdk
 

--- a/provisioning/pre-package-bootstrap3.sh
+++ b/provisioning/pre-package-bootstrap3.sh
@@ -1,6 +1,6 @@
 set -e
 
-mkdir /evidence
+mkdir -p /evidence
 if grep 'vagrant' /etc/passwd
 then
     chown vagrant:vagrant /evidence
@@ -10,7 +10,7 @@ else
 fi
 
 # Generate a snapshot now so it's easier to snapshot before an inspection
-mkdir /backup
+mkdir -p /backup
 rdiff-backup --include-filelist $user_home/filesystem-snapshot.txt / /backup
 chown -R vagrant:vagrant /backup
 


### PR DESCRIPTION
This PR updates the provisioned gradle to 3.5.1 as gradle-3.1 has been unpublished. It also improves the provision shell script to not fail on creating an existing directory by adding the -p flag to mkdir.